### PR TITLE
Support in_aggregate and out_aggregate fields for OrderBy class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets.Gql/issues/4
+Your prepared branch: issue-4-cacd45eb
+Your prepared working directory: /tmp/gh-issue-solver-1757741964626
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets.Gql/issues/4
-Your prepared branch: issue-4-cacd45eb
-Your prepared working directory: /tmp/gh-issue-solver-1757741964626
-
-Proceed.

--- a/csharp/Platform.Data.Doublets.Gql.Schema/DcDgLinksAggregateOrderBy.cs
+++ b/csharp/Platform.Data.Doublets.Gql.Schema/DcDgLinksAggregateOrderBy.cs
@@ -1,0 +1,29 @@
+using Platform.Data.Doublets.Gql.Schema.Enums;
+
+namespace Platform.Data.Doublets.Gql.Schema
+{
+    public class DcDgLinksAggregateOrderBy
+    {
+        public LinksFieldsOrderBy avg { get; set; }
+
+        public OrderBy? count { get; set; }
+
+        public LinksFieldsOrderBy max { get; set; }
+
+        public LinksFieldsOrderBy min { get; set; }
+
+        public LinksFieldsOrderBy stddev { get; set; }
+
+        public LinksFieldsOrderBy stddev_pop { get; set; }
+
+        public LinksFieldsOrderBy stddev_samp { get; set; }
+
+        public LinksFieldsOrderBy sum { get; set; }
+
+        public LinksFieldsOrderBy var_pop { get; set; }
+
+        public LinksFieldsOrderBy var_samp { get; set; }
+
+        public LinksFieldsOrderBy variance { get; set; }
+    }
+}

--- a/csharp/Platform.Data.Doublets.Gql.Schema/LinksOrderBy.cs
+++ b/csharp/Platform.Data.Doublets.Gql.Schema/LinksOrderBy.cs
@@ -11,9 +11,9 @@ namespace Platform.Data.Doublets.Gql.Schema
 
         public OrderBy? id { get; set; }
 
-        public LinksAggregateOrderByInputType in_aggregate { get; set; }
+        public DcDgLinksAggregateOrderByInputType in_aggregate { get; set; }
 
-        public LinksAggregateOrderByInputType out_aggregate { get; set; }
+        public DcDgLinksAggregateOrderByInputType out_aggregate { get; set; }
 
         public LinksOrderBy to { get; set; }
 

--- a/csharp/Platform.Data.Doublets.Gql.Schema/Types/Input/DcDgLinksAggregateOrderByInputType.cs
+++ b/csharp/Platform.Data.Doublets.Gql.Schema/Types/Input/DcDgLinksAggregateOrderByInputType.cs
@@ -1,0 +1,26 @@
+using GraphQL.Types;
+using Platform.Data.Doublets.Gql.Schema.Types.Enums;
+
+namespace Platform.Data.Doublets.Gql.Schema.Types.Input
+{
+    using MappedType = DcDgLinksAggregateOrderBy;
+
+    public class DcDgLinksAggregateOrderByInputType : InputObjectGraphType<MappedType>
+    {
+        public DcDgLinksAggregateOrderByInputType()
+        {
+            Name = "dc_dg_links_aggregate_order_by";
+            Field<LinksFieldsAvgOrderByInputType>(nameof(MappedType.avg));
+            Field<OrderByEnumType>(nameof(MappedType.count));
+            Field<LinksFieldsMaxOrderByInputType>(nameof(MappedType.max));
+            Field<LinksFieldsMinOrderByInputType>(nameof(MappedType.min));
+            Field<LinksFieldsStdDevOrderByInputType>(nameof(MappedType.stddev));
+            Field<LinksFieldsStdDevPopOrderByInputType>(nameof(MappedType.stddev_pop));
+            Field<LinksFieldsStdDevSampOrderByInputType>(nameof(MappedType.stddev_samp));
+            Field<LinksFieldsSumOrderByInputType>(nameof(MappedType.sum));
+            Field<LinksFieldsVarPopOrderByInputType>(nameof(MappedType.var_pop));
+            Field<LinksFieldsVarSampOrderByInputType>(nameof(MappedType.var_samp));
+            Field<LinksFieldsVarianceOrderByInputType>(nameof(MappedType.variance));
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets.Gql.Schema/Types/Input/LinksOrderByInputType.cs
+++ b/csharp/Platform.Data.Doublets.Gql.Schema/Types/Input/LinksOrderByInputType.cs
@@ -13,8 +13,8 @@ namespace Platform.Data.Doublets.Gql.Schema.Types.Input
             Field<LinksOrderByInputType>(nameof(MappedType.from));
             Field<OrderByEnumType>(nameof(MappedType.from_id));
             Field<OrderByEnumType>(nameof(MappedType.id));
-            Field<LinksAggregateOrderByInputType>(nameof(MappedType.in_aggregate));
-            Field<LinksAggregateOrderByInputType>(nameof(MappedType.out_aggregate));
+            Field<DcDgLinksAggregateOrderByInputType>(nameof(MappedType.in_aggregate));
+            Field<DcDgLinksAggregateOrderByInputType>(nameof(MappedType.out_aggregate));
             Field<LinksOrderByInputType>(nameof(MappedType.to));
             Field<OrderByEnumType>(nameof(MappedType.to_id));
             Field<LinksOrderByInputType>(nameof(MappedType.type));


### PR DESCRIPTION
## Summary
- Added `DcDgLinksAggregateOrderBy` class with the same structure as `LinksAggregateOrderBy`
- Created `DcDgLinksAggregateOrderByInputType` with GraphQL name `dc_dg_links_aggregate_order_by`
- Updated `LinksOrderBy` class to use `DcDgLinksAggregateOrderByInputType` for `in_aggregate` and `out_aggregate` fields
- Updated `LinksOrderByInputType` to reference the new aggregate type

## Test plan
- [x] Built the C# schema project successfully
- [x] No compilation errors found
- [x] All existing functionality preserved with new aggregate type

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #4